### PR TITLE
Bugfix/image size

### DIFF
--- a/art-community-platform/mobile/screens/Profile.js
+++ b/art-community-platform/mobile/screens/Profile.js
@@ -1,5 +1,6 @@
 import { StyleSheet, Text, View, Image,ScrollView, SafeAreaView, Dimensions } from "react-native";
 
+const dimensions = Dimensions.get("window");
 const Profile = () => {
   return (
     <SafeAreaView style={styles.container}>

--- a/art-community-platform/mobile/screens/Profile.js
+++ b/art-community-platform/mobile/screens/Profile.js
@@ -81,8 +81,8 @@ const styles = StyleSheet.create({
     marginTop:10,
   },
   photo:{
-    width:113,
-    height:113,
+    width: dimensions.width*0.28,
+    height: dimensions.width*0.28,
     marginTop:5,
     marginRight:5,
   }

--- a/art-community-platform/mobile/screens/Profile.js
+++ b/art-community-platform/mobile/screens/Profile.js
@@ -1,4 +1,4 @@
-import { StyleSheet, Text, View, Image,ScrollView, SafeAreaView } from "react-native";
+import { StyleSheet, Text, View, Image,ScrollView, SafeAreaView, Dimensions } from "react-native";
 
 const Profile = () => {
   return (


### PR DESCRIPTION
When the images were not set according to the size of the screen, they started to appear with different organization on different screen sizes. To solve this problem, it was set to 0.28 times the screen width and width.