### PR TITLE
Unfollow endpoint

### DIFF
--- a/art-community-platform/backend/app/api/helpers/user_helpers.py
+++ b/art-community-platform/backend/app/api/helpers/user_helpers.py
@@ -69,6 +69,7 @@ def validate_username_helper(username):
         return [False, "username can't be shorter than 5 characters"]
     return [True, ""]
 
+
 # deletes follower_id from followers list of user with followed_id
 def delete_user_from_followers(follower_id, followed_id):
     follower_user = None

--- a/art-community-platform/backend/app/api/urls.py
+++ b/art-community-platform/backend/app/api/urls.py
@@ -45,6 +45,7 @@ urlpatterns = [
     path('upload-image', upload_image, name='upload_image'),
     path('exhibition', create_exhibition, name='create_exhibition'),
     path('follow', follow, name='follow'),
+    path('unfollow', unfollow, name='unfollow'),
     path('favourite', favourite, name='favourite'),
     path('comment', comment, name='comment'),
     path('tag', create_tag, name='create_tag'),


### PR DESCRIPTION
Unfollow endpoint is implemented.

* Created a new endpoint accepting POST requests. This endpoint accepts a user token and a user id in the request body. User token will be token of the follower, while the id will be the followed user's id.  The endpoint  makes follower user unfollow the followed user.
*  If users with given token/id doesn't exists or there is no following relationship between them, endpoint returns 400 Bad request. Else case endpoint returns 200 Ok.