### PR TITLE
Added Art Item Recommendation Unit Tests

### DIFF
--- a/art-community-platform/backend/app/api/tests/test_recommend.py
+++ b/art-community-platform/backend/app/api/tests/test_recommend.py
@@ -1,0 +1,89 @@
+from django.test import TestCase, Client
+from django.test.client import RequestFactory
+from django.urls import reverse
+import json
+from ..models.art_item import ArtItem
+from faker import Faker
+import random
+
+from ..views.auth import signup
+from ..views.user import *
+from ..views.follow import *
+from ..views.profile import *
+from ..views.art_item import *
+from ..views.recommend import *
+
+fake = Faker()
+
+date = fake.date()
+
+# we will have 3 users
+usernames = [fake.username() for i in range(3)]
+passwords = [fake.password() for i in range(3)]
+emails = [fake.email() for i in range(3)]
+names = [fake.name() for i in range(3)]
+birthdates = [fake.date() for i in range(3)]
+tokens = [hashlib.sha256((usernames[i] + passwords[i] + emails[i]).encode('utf-8')).hexdigest() for i in range(3)]
+headers = [{"HTTP_AUTHORIZATION": tokens[i]} for i in range(3)]
+
+
+class TestProfile(TestCase):
+
+    def setUp(self):
+        # Setup run before every test method.
+        # Every test needs access to the request factory.
+        self.factory = RequestFactory()
+
+        # we will have 3 users
+        self.users = [User.objects.create(
+                                        name=names[i], birthdate=birthdates[i], username=usernames[i],
+                                        password=passwords[i], email=emails[i], token=tokens[i]
+                                        ) for i in range(3)]
+        self.arts = []
+
+        # we will have 30 arts,
+        # 20 of them will have tag: impressionist
+        # 10 of them will have tag: medieval
+
+        # user3 will add first 10 impressionist arts and first 10 medieval arts to her/his likes
+        # user2 will add first 5 medieval arts to her/his arts
+        for i in range(10):
+            self.arts.append(
+                ArtItem.objects.create(
+                                        tags=["impressionist"],
+                                        favourites=[self.users[2].id]
+                                      )
+                            )
+        for i in range(10):
+            self.arts.append(
+                ArtItem.objects.create(
+                                        tags=["impressionist"],
+                                      )
+                            )
+        for i in range(5):
+            self.arts.append(
+                ArtItem.objects.create(
+                                        tags=["medieval"],
+                                        favourites=[self.users[1].id, self.users[2].id]
+                                      )
+                            )
+        for i in range(5):
+            self.arts.append(
+                ArtItem.objects.create(
+                                        tags=["medieval"],
+                                        favourites=[self.users[2].id]
+                                      )
+                            )
+
+
+    def test_users_having_less_than_five_favourites(self):
+        req = self.factory.get('/api/v1/users/'+str(self.user.id)+'/get_profile_info', content_type="application/json")
+        res = get_profile_info(req, self.user.id)
+        res_json = json.loads(res.content)
+
+        self.assertEqual(res.status_code, 200)
+
+        # check the values
+        self.assertEqual(res_json['profile_img_url'], self.user.profile_img_url)
+        self.assertEqual(res_json['birthdate'], self.user.birthdate)
+        self.assertEqual(res_json['location'], self.user.location)

--- a/art-community-platform/backend/app/api/tests/test_recommend.py
+++ b/art-community-platform/backend/app/api/tests/test_recommend.py
@@ -91,3 +91,17 @@ class TestProfile(TestCase):
                 continue
             self.assertTrue(art.id in recommendation_ids, "missing recommendation")
 
+    def test_users_having_gte_five_favourites(self):
+        req = self.factory.get('/api/v1/recommend/art-items/'+str(self.users[1].id), content_type="application/json")
+        res = recommend_art_items(req, self.users[1].id)
+        res_json = json.loads(res.content)
+
+        self.assertEqual(res.status_code, 200)
+        # there are 10 art items having mutual tags with user[1]'s favouites
+        self.assertEqual(len(res_json['recommendations']), 10)
+
+        # check the values
+        recommendation_ids = [art['id'] for art in res_json['recommendations']]
+        for art in enumerate(self.arts):
+            self.assertTrue("medieval" in art.tags, "recommendation not having mutual tags with user's favourites")
+

--- a/art-community-platform/backend/app/api/tests/test_recommend.py
+++ b/art-community-platform/backend/app/api/tests/test_recommend.py
@@ -5,6 +5,7 @@ import json
 from ..models.art_item import ArtItem
 from faker import Faker
 import random
+import unittest
 
 from ..views.auth import signup
 from ..views.user import *
@@ -77,13 +78,16 @@ class TestProfile(TestCase):
 
 
     def test_users_having_less_than_five_favourites(self):
-        req = self.factory.get('/api/v1/users/'+str(self.user.id)+'/get_profile_info', content_type="application/json")
-        res = get_profile_info(req, self.user.id)
+        req = self.factory.get('/api/v1/recommend/art-items/'+str(self.users[0].id), content_type="application/json")
+        res = recommend_art_items(req, self.users[0].id)
         res_json = json.loads(res.content)
 
         self.assertEqual(res.status_code, 200)
 
         # check the values
-        self.assertEqual(res_json['profile_img_url'], self.user.profile_img_url)
-        self.assertEqual(res_json['birthdate'], self.user.birthdate)
-        self.assertEqual(res_json['location'], self.user.location)
+        recommendation_ids = [art['id'] for art in res_json['recommendations']]
+        for art in enumerate(self.arts):
+            if len(art.favourites) == 0:
+                continue
+            self.assertTrue(art.id in recommendation_ids, "missing recommendation")
+


### PR DESCRIPTION
* Created a new python code file to add tests for recommendations in [this directory](https://github.com/bounswe/bounswe2022group9/tree/master/art-community-platform/backend/app/api/tests), name it "test_recommend"
* Wrote a view test, testing the endpoint's behavior when the user has less than 5 favorite items.
    * return value of the endpoint should be the most popular 20 art items in the system (according the sum of number of comments and likes)
* Wrote a view test, testing the endpoint's behavior when the user has greater than or equal to 5 favorite items.,
    * return value of the endpoint should be art items having the same tags with the user's favorite art items)

Used the "faker" library while generating mock data.

Test scenario: There will be 3 users, and 30 art items (20 of them having "impressionist" tag, 10 of them having "medieval" tag)
The first user will not have any favourites
The second user will add 5 arts (with "medieval" tag) to his favourites
The third user will add 10 arts with "impressionist" tag and 10 arts with "medieval" tag to his art items.

Recommendations to the first user will be 20 art items consisting of 10 impressionist and 10 medieval tagged art items. (this is the distribution of art items added to favourites list most in this test) Note that system returning the most popular 20 art items since user didn't add anything to her/his favourites.
Recommendations to the second user will be 10 art items having the medieval tag, since he has 5 favourites having medieval tag.