### PR TITLE
[Backend] User level information added to profile

### DIFF
--- a/art-community-platform/backend/app/api/tests/test_profile.py
+++ b/art-community-platform/backend/app/api/tests/test_profile.py
@@ -36,6 +36,8 @@ class TestProfile(TestCase):
         self.new_birthdate = fake.date()
         self.new_location = 'Ankara'
         self.new_name = fake.name()
+        self.new_art_items = [1, 2, 3, 4, 5, 6, 7]
+        self.new_comments = [1, 2, 3, 4, 5, 6, 7, 8]
 
     def test_get_profile_info(self):
 
@@ -49,6 +51,7 @@ class TestProfile(TestCase):
         self.assertEqual(res_json['profile_img_url'], self.user.profile_img_url)
         self.assertEqual(res_json['birthdate'], self.user.birthdate)
         self.assertEqual(res_json['location'], self.user.location)
+        self.assertEqual(res_json['user_level'], (len(self.new_art_items) + len(self.new_comments)) / 5)
 
     def test_update_profile_info(self):
 

--- a/art-community-platform/backend/app/api/tests/test_user.py
+++ b/art-community-platform/backend/app/api/tests/test_user.py
@@ -56,6 +56,7 @@ class TestUser(TestCase):
         self.assertEqual(res_json['password'], password)
         self.assertEqual(res_json['email'], email)
         self.assertEqual(res_json['birthdate'], birthdate)
+        self.assertEqual(res_json['user_level'], (len(res_json["art_items"]) + len(res_json["comments"])) / 5)
 
     def test_get_followers_of_users(self):
         request = self.factory.get('/api/v1/users/1/followers', **header)

--- a/art-community-platform/backend/app/api/views/profile.py
+++ b/art-community-platform/backend/app/api/views/profile.py
@@ -67,12 +67,17 @@ def get_profile_info(req, user_id):
     following_count = None
     try:
         following_count = len(user.followings)
+        user_level = (len(user.comments) + len(art_items)) / 5
     except:
         following_count = 0
+        user_level = 1
+
     data = {"id": user.id, "username": user.username, "email": user.email, "birthdate": user.birthdate,
             "name": user.name,
             "art_items": art_items,
             "follower_count": follower_count,
             "following_count": following_count,
-            "profile_img_url": user.profile_img_url, "location": user.location, "password": user.password}
+            "profile_img_url": user.profile_img_url, "location": user.location,
+            "password": user.password, "user_level": user_level}
+
     return JsonResponse(data)

--- a/art-community-platform/backend/app/api/views/user.py
+++ b/art-community-platform/backend/app/api/views/user.py
@@ -68,12 +68,17 @@ def get_user_by_id(req, user_id):
     followings_count = len(followings["followings"])
     art_item_count = len(art_item_list["art_items"])
 
+    try:
+        user_level = (len(u.comments) + art_item_count) / 5
+    except:
+        user_level = 1
 
     try:
         resp = {"id": u.id, "username": u.username, "email": u.email,
                 "birthdate": u.birthdate, "name": u.name, "art_items:": art_items,
                 "profile_img_url": u.profile_img_url, "location": u.location, "is_following": is_following,
-                "follower_count":followers_count,"following_count":followings_count,"art_item_count":art_item_count}
+                "follower_count":followers_count,"following_count":followings_count,
+                "art_item_count":art_item_count, "user_level": user_level}
     except:
         return HttpResponse('response can not created', status=404)
 


### PR DESCRIPTION
- A new information which shows level of a user added to the profile info of the user.
- This level is calculated by using number of comments done by that user and number of art items shared by that user.
- The formula is for now ((number of comments) + (number of art items) / 5).
- Get user by id and Get profile info endpoints updated according to this [issue]()
- Unit tests of endpoints above are also updated.
- As feature work; we can use this level info for restricting some functionalities for some users below a specific level.