### PR TITLE
bugfix: function call parameter fixed

### DIFF
--- a/art-community-platform/backend/app/api/tests/test_urls.py
+++ b/art-community-platform/backend/app/api/tests/test_urls.py
@@ -139,3 +139,6 @@ class TestUrls(TestCase):
         url = reverse('annotation/:id')
         self.assertEqual(resolve(url).func, update_annotation)
 
+    def test_notification_url_is_resolved(self):
+        url = reverse('get_notification_by_receiver_id')
+        self.assertEqual(resolve(url).func, get_notification_by_receiver_id)

--- a/art-community-platform/backend/app/api/views/recommend.py
+++ b/art-community-platform/backend/app/api/views/recommend.py
@@ -18,7 +18,7 @@ def recommend_art_items(req, user_id):
     if is_new_user_for_art_recommendation(u):
         return JsonResponse({"recommendations": popular_art_items()})
     else:
-        tags = get_tags_of_favourites()
+        tags = get_tags_of_favourites(u)
         arts = ArtItem.objects.all()
         art_items_to_recommend = []
         for art in arts:


### PR DESCRIPTION
* In recommend art items endpoint, a helper function was called with wrong parameter and this was causing some 500 server errors, fixed now
* Url test added to notification endpoint