### PR TITLE
[BUG] Fix: owner id check added to recommendations

### DIFF
--- a/art-community-platform/backend/app/api/helpers/recommendation_helpers.py
+++ b/art-community-platform/backend/app/api/helpers/recommendation_helpers.py
@@ -52,6 +52,7 @@ def get_popular_users():
     #This is the list that is sorted by number of followers in decreasing order
     new_list = sorted(user_list,key=lambda user: len(user.followers),reverse=True)
 
+    resp = []
 
     if len(new_list)<8:
          return [get_user_by_id_helper(u.id) for u in new_list]
@@ -83,7 +84,11 @@ def get_related_users(user_id):
     # removing duplicates
     new_list = list(set(second_level_following))
 
-    toReturn = [get_user_by_id_helper(u) for u in new_list]
+    # toReturn = [get_user_by_id_helper(u) for u in new_list]
+    toReturn = []
+    for u in new_list:
+        if u != user_id:
+            toReturn.append(get_user_by_id_helper(u))
 
     return toReturn
 

--- a/art-community-platform/backend/app/api/views/recommend.py
+++ b/art-community-platform/backend/app/api/views/recommend.py
@@ -23,7 +23,8 @@ def recommend_art_items(req, user_id):
         art_items_to_recommend = []
         for art in arts:
             if set(art.tags).intersection(tags):
-                art_items_to_recommend.append(get_art_item_by_id_helper(art.id))
+                if art.owner_id != user_id:
+                    art_items_to_recommend.append(get_art_item_by_id_helper(art.id))
         return JsonResponse({"recommendations" : list(art_items_to_recommend)})
 
 


### PR DESCRIPTION
There was a small bug in recommendation endpoint that it was returning recommended art item to user containing its own art items. I have added a small check for owner id and excluded the own art items from recommendations.